### PR TITLE
Update AtlassianConnect to accept no app during __init__ if needed

### DIFF
--- a/flask_atlassian_connect/base.py
+++ b/flask_atlassian_connect/base.py
@@ -42,22 +42,15 @@ class AtlassianConnect(object):
     """
     def __init__(self, app=None, client_class=AtlassianConnectClient):
         self.app = app
-        if app is not None:
-            self.init_app(app)
+
         self.descriptor = {
-            "name": app.config.get('ADDON_NAME', ""),
-            "description": app.config.get('ADDON_DESCRIPTION', ""),
-            "key": app.config.get('ADDON_KEY'),
             "authentication": {"type": "jwt"},
-            "scopes": app.config.get('ADDON_SCOPES', ["READ"]),
-            "vendor": {
-                "name": app.config.get('ADDON_VENDOR_NAME'),
-                "url": app.config.get('ADDON_VENDOR_URL')
-            },
             "lifecycle": {},
             "links": {
             },
         }
+        if app is not None:
+            self.init_app(app)
         self.client_class = client_class
         self.auth = _SimpleAuthenticator(addon=self)
         self.sections = {}
@@ -75,6 +68,19 @@ class AtlassianConnect(object):
         app.route('/atlassian_connect/<section>/<name>',
                   methods=['GET', 'POST'])(self._handler_router)
         app.context_processor(self._atlassian_jwt_post_token)
+
+        app_descriptor = {
+            "name": app.config.get('ADDON_NAME', ""),
+            "description": app.config.get('ADDON_DESCRIPTION', ""),
+            "key": app.config.get('ADDON_KEY'),
+
+            "scopes": app.config.get('ADDON_SCOPES', ["READ"]),
+            "vendor": {
+                "name": app.config.get('ADDON_VENDOR_NAME'),
+                "url": app.config.get('ADDON_VENDOR_URL')
+            },
+        }
+        self.descriptor.update(app_descriptor)
 
     def _atlassian_jwt_post_token(self):
         if not getattr(g, 'ac_client', None):

--- a/flask_atlassian_connect/base.py
+++ b/flask_atlassian_connect/base.py
@@ -63,7 +63,7 @@ class AtlassianConnect(object):
             App Object
         :type app: :py:class:`flask.Flask`
         """
-        if self.app is None:
+        if self.app is not None:
             self.app = app
 
         app.route('/atlassian_connect/descriptor',

--- a/flask_atlassian_connect/base.py
+++ b/flask_atlassian_connect/base.py
@@ -63,6 +63,9 @@ class AtlassianConnect(object):
             App Object
         :type app: :py:class:`flask.Flask`
         """
+        if self.app is None:
+            self.app = app
+
         app.route('/atlassian_connect/descriptor',
                   methods=['GET'])(self._get_descriptor)
         app.route('/atlassian_connect/<section>/<name>',

--- a/flask_atlassian_connect/tests/test_addon.py
+++ b/flask_atlassian_connect/tests/test_addon.py
@@ -291,5 +291,20 @@ class ACFlaskTestCase(unittest.TestCase):
         self.assertEquals('', response.data)
 
 
+
+class NoAppACFlaskTestCase(ACFlaskTestCase):
+    """Test Case"""
+    def setUp(self):
+        self.app = Flask("app")
+        self.app.testing = True
+        self.ac = AtlassianConnect(client_class=_TestClient)
+        _TestClient.reset()
+        self.client = self.app.test_client()
+        self.ac.lifecycle('installed')(decorator_noop)
+        self.ac.init_app(self.app)
+
+    def tearDown(self):
+        pass
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Changes:
- define only part of the descriptor initially
- run `AtlassianConnect.init_app` only after `AtlassianConnect.descriptor` has been first defined in `__init__`
- update `self.descriptor` in `AtlassianConnect.init_app`
- in `AtlassianConnect.init_app`, set the app when initializing if not set