### PR TITLE
Apply 2to3 conversions and fixup failing tests

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,9 +53,9 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'Flask-AtlassianConnect'
-copyright = u'2017, Gavin Mogan'
-author = u'Gavin Mogan'
+project = 'Flask-AtlassianConnect'
+copyright = '2017, Gavin Mogan'
+author = 'Gavin Mogan'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -148,8 +148,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'flask_atlassian_connect.tex', u'flask_atlassian_connect Documentation',
-     u'Gavin Mogan', 'manual'),
+    (master_doc, 'flask_atlassian_connect.tex', 'flask_atlassian_connect Documentation',
+     'Gavin Mogan', 'manual'),
 ]
 
 
@@ -158,7 +158,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'flask_atlassian_connect', u'flask_atlassian_connect Documentation',
+    (master_doc, 'flask_atlassian_connect', 'flask_atlassian_connect Documentation',
      [author], 1)
 ]
 
@@ -169,7 +169,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'flask_atlassian_connect', u'flask_atlassian_connect Documentation',
+    (master_doc, 'flask_atlassian_connect', 'flask_atlassian_connect Documentation',
      author, 'flask_atlassian_connect', 'One line description of project.',
      'Miscellaneous'),
 ]

--- a/flask_atlassian_connect/base.py
+++ b/flask_atlassian_connect/base.py
@@ -10,7 +10,7 @@ from .client import AtlassianConnectClient
 
 try:
     # python2
-    from urllib import urlencode
+    from urllib.parse import urlencode
 except ImportError:
     # python3
     from urllib.parse import urlencode
@@ -122,7 +122,7 @@ class AtlassianConnect(object):
         if method is None:
             (self.app or current_app).logger.error(
                 'Invalid handler for %s -- %s' % (section, name))
-            print (section, name, self.sections)
+            print((section, name, self.sections))
             abort(404)
         ret = method()
         if ret is not None:
@@ -441,16 +441,16 @@ class AtlassianConnect(object):
             """Show all clients in the database"""
             from json import dumps
             with (self.app or current_app).app_context():
-                print dumps([
+                print(dumps([
                     dict(c) for c in self.client_class.all()
-                ])
+                ]))
 
         @task
         def show(ctx, clientKey):
             """Lookup one client from the database"""
             from json import dumps
             with (self.app or current_app).app_context():
-                print dumps(dict(self.client_class.load(clientKey)))
+                print(dumps(dict(self.client_class.load(clientKey))))
 
         @task
         def install(ctx, data):
@@ -459,14 +459,14 @@ class AtlassianConnect(object):
             with (self.app or current_app).app_context():
                 client = loads(data)
                 self.client_class.save(client)
-                print "Added"
+                print("Added")
 
         @task()
         def uninstall(ctx, clientKey):
             """Remove a given client from the database"""
             with (self.app or current_app).app_context():
                 self.client_class.delete(clientKey)
-                print "Deleted"
+                print("Deleted")
 
         ns = Collection('clients')
         ns.add_task(list)

--- a/flask_atlassian_connect/base.py
+++ b/flask_atlassian_connect/base.py
@@ -10,7 +10,7 @@ from .client import AtlassianConnectClient
 
 try:
     # python2
-    from urllib.parse import urlencode
+    from urllib import urlencode
 except ImportError:
     # python3
     from urllib.parse import urlencode

--- a/flask_atlassian_connect/client.py
+++ b/flask_atlassian_connect/client.py
@@ -16,7 +16,7 @@ class AtlassianConnectClient(object):
         self.clientKey = None
         self.sharedSecret = None
         self.baseUrl = None
-        for k, v in kwargs.items():
+        for k, v in list(kwargs.items()):
             setattr(self, k, v)
 
     @staticmethod

--- a/flask_atlassian_connect/tests/test_addon.py
+++ b/flask_atlassian_connect/tests/test_addon.py
@@ -90,8 +90,8 @@ class ACFlaskTestCase(unittest.TestCase):
     def test_descriptor_stuff(self):
         """Grab the descriptor and make sure its valid"""
         response = self.client.get('/atlassian_connect/descriptor')
-        self.assertEquals(200, response.status_code)
-        self.assertEquals(
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(
             {"type": "jwt"},
             json.loads(response.get_data())['authentication']
         )
@@ -99,7 +99,7 @@ class ACFlaskTestCase(unittest.TestCase):
     @unittest.skip("slow")
     def test_descriptor_should_validate(self):
         rv = self.client.get('/atlassian_connect/descriptor')
-        self.assertEquals(200, rv.status_code)
+        self.assertEqual(200, rv.status_code)
         rv = requests.post(
             'https://atlassian-connect-validator.herokuapp.com/validate',
             data={'descriptor': rv.data, 'product': 'jira'}
@@ -119,7 +119,7 @@ class ACFlaskTestCase(unittest.TestCase):
                 '/atlassian_connect/lifecycle/installed',
                 data=json.dumps(client),
                 content_type='application/json')
-            self.assertEquals(204, response.status_code)
+            self.assertEqual(204, response.status_code)
 
     def test_lifecycle_installed_multiple_no_auth(self):
         """Multiple requests should fail unless auth is provided the second time"""
@@ -134,11 +134,11 @@ class ACFlaskTestCase(unittest.TestCase):
             rv = self.client.post('/atlassian_connect/lifecycle/installed',
                                   data=json.dumps(client),
                                   content_type='application/json')
-            self.assertEquals(204, rv.status_code)
+            self.assertEqual(204, rv.status_code)
             rv = self.client.post('/atlassian_connect/lifecycle/installed',
                                   data=json.dumps(client),
                                   content_type='application/json')
-            self.assertEquals(401, rv.status_code)
+            self.assertEqual(401, rv.status_code)
 
     def test_lifecycle_installed_multiple_with_auth(self):
         """Multiple requests  should update if the second time has auth"""
@@ -154,7 +154,7 @@ class ACFlaskTestCase(unittest.TestCase):
             rv = self.client.post('/atlassian_connect/lifecycle/installed',
                                   data=json.dumps(client),
                                   content_type='application/json')
-            self.assertEquals(204, rv.status_code)
+            self.assertEqual(204, rv.status_code)
             # Add auth
             auth = encode_token(
                 'GET',
@@ -165,7 +165,7 @@ class ACFlaskTestCase(unittest.TestCase):
                                   data=json.dumps(client),
                                   content_type='application/json',
                                   headers={'Authorization': 'JWT ' + auth})
-            self.assertEquals(204, rv.status_code)
+            self.assertEqual(204, rv.status_code)
 
     @requests_mock.Mocker()
     def test_lifecycle_installed_multiple_invalid_auth(self, m):
@@ -180,7 +180,7 @@ class ACFlaskTestCase(unittest.TestCase):
         rv = self.client.post('/atlassian_connect/lifecycle/installed',
                               data=json.dumps(client),
                               content_type='application/json')
-        self.assertEquals(204, rv.status_code)
+        self.assertEqual(204, rv.status_code)
         # Add auth
         auth = encode_token(
             'GET',
@@ -191,20 +191,20 @@ class ACFlaskTestCase(unittest.TestCase):
                               data=json.dumps(client),
                               content_type='application/json',
                               headers={'Authorization': 'JWT ' + auth})
-        self.assertEquals(401, rv.status_code)
+        self.assertEqual(401, rv.status_code)
 
     def test_webook(self):
         self.ac.webhook('jira:issue_created', filter="project is 'IM'")(
             decorator_noop)
 
         response = self.client.get('/atlassian_connect/descriptor')
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         self.assertIn({
-            u"event": u"jira:issue_created",
-            u"excludeBody": False,
-            u"filter": u"project is 'IM'",
-            u"url": u"/atlassian_connect/webhook/jiraissue_created"
-        }, json.loads(response.data)["modules"]["webhooks"])
+            "event": "jira:issue_created",
+            "excludeBody": False,
+            "filter": "project is 'IM'",
+            "url": "/atlassian_connect/webhook/jiraissue_created"
+        }, json.loads(response.get_data(as_text=True))["modules"]["webhooks"])
 
         response = self._request_post(
             'test_webhook',
@@ -214,7 +214,7 @@ class ACFlaskTestCase(unittest.TestCase):
                 "foo": "bar"
             })  # FIXME - not a real event
         )
-        self.assertEquals(204, response.status_code)
+        self.assertEqual(204, response.status_code)
 
     def test_webpanel(self):
         """Confirm webpanel decorator works right"""
@@ -228,7 +228,7 @@ class ACFlaskTestCase(unittest.TestCase):
             }])(decorator_a_string)
 
         response = self.client.get('/atlassian_connect/descriptor')
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
         self.assertIn({
             "conditions": [
                 {
@@ -240,30 +240,30 @@ class ACFlaskTestCase(unittest.TestCase):
             "location": "atl.jira.view.issue.right.context",
             "name": {"value": "Bamboo Employee Information"},
             "url": "/atlassian_connect/webpanel/userPanel?issueKey={issue.key}"
-        }, json.loads(response.data)["modules"]["webPanels"])
+        }, json.loads(response.get_data(as_text=True))["modules"]["webPanels"])
 
         response = self._request_get(
             'test_webpanel',
             '/atlassian_connect/webpanel/userPanel?issueKey=TEST-1')
-        self.assertEquals(200, response.status_code)
-        self.assertIn('<h1>Something</h1>', response.data)
+        self.assertEqual(200, response.status_code)
+        self.assertIn('<h1>Something</h1>', response.get_data(as_text=True))
 
     def test_module(self):
         """Confirm webpanel decorator works right"""
         self.ac.module(name="Configure", key="configurePage")(decorator_noop)
 
         response = self.client.get('/atlassian_connect/descriptor')
-        self.assertEquals(200, response.status_code)
-        self.assertEquals({
-            u"key": u"configurePage",
-            u"name": {u"value": u"Configure"},
-            u"url": "/atlassian_connect/module/configurePage"
-        }, json.loads(response.data)["modules"]["configurePage"])
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({
+            "key": "configurePage",
+            "name": {"value": "Configure"},
+            "url": "/atlassian_connect/module/configurePage"
+        }, json.loads(response.get_data(as_text=True))["modules"]["configurePage"])
 
         response = self._request_get(
             'test_module',
             "/atlassian_connect/module/configurePage")
-        self.assertEquals(204, response.status_code)
+        self.assertEqual(204, response.status_code)
 
     def test_decorator_return_values(self):
         """Confirm webpanel decorator works right"""
@@ -274,21 +274,22 @@ class ACFlaskTestCase(unittest.TestCase):
         response = self._request_get(
             'test_decorator_return_values',
             '/atlassian_connect/webpanel/aString?issueKey=TEST-1')
-        self.assertEquals(200, response.status_code)
-        self.assertIn('<h1>Something</h1>', response.data)
-        self.assertIn('/atlassian_connect/webpanel/aString?jwt=', response.data)
+        self.assertEqual(200, response.status_code)
+        self.assertIn('<h1>Something</h1>', response.get_data(as_text=True))
+        self.assertIn('/atlassian_connect/webpanel/aString?', response.get_data(as_text=True))
+        self.assertIn('jwt=', response.get_data(as_text=True))
 
         response = self._request_get(
             'test_decorator_return_values',
             '/atlassian_connect/webpanel/noop?issueKey=TEST-1')
-        self.assertEquals(204, response.status_code)
-        self.assertEquals('', response.data)
+        self.assertEqual(204, response.status_code)
+        self.assertEqual('', response.get_data(as_text=True))
 
         response = self._request_get(
             'test_decorator_return_values',
             '/atlassian_connect/webpanel/none?issueKey=TEST-1')
-        self.assertEquals(204, response.status_code)
-        self.assertEquals('', response.data)
+        self.assertEqual(204, response.status_code)
+        self.assertEqual('', response.get_data(as_text=True))
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,8 @@ setup(
     install_requires=io.open('requirements/runtime.txt').readlines(),
     setup_requires=['pytest-runner'],
     keywords=['atlassian connect', 'flask', 'jira', 'confluence'],
-    tests_require=filter(lambda x: not x.startswith('-'), io.open(
-        'requirements/dev.txt').readlines()),
+    tests_require=[x for x in io.open(
+        'requirements/dev.txt').readlines() if not x.startswith('-')],
     classifiers=[
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: Implementation :: PyPy",


### PR DESCRIPTION
Tests failed with test_client returning bytes instead of string. Doing response.get_data(as_text=True)
returns a string object as expected by the tests. It also seems like one of the tests were expecting
the query parameters to be in a determined order. 

Tested and working with python 3.6.1 - installed the add-on to a Confluence Cloud instance and successfully received 'installed' lifecycle hook.  

I have not tested these changes on python 2.7 and I'm not expecting this to get merged in without much more scrutiny, but figured I would share what worked for me in case its helpful 👍 

```
127.0.0.1 - - [17/Sep/2017 14:43:20] "GET /atlassian_connect/descriptor HTTP/1.1" 200 -
New client installed!!!!
<flask_atlassian_connect.client.AtlassianConnectClient object at 0x7f7156676f60>
127.0.0.1 - - [17/Sep/2017 14:43:26] "POST /atlassian_connect/lifecycle/installed?user_key=<redacted> HTTP/1.1" 204 -
```